### PR TITLE
Update endorsement kind per Octez v20

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ var query = async () => {
   head.operations.forEach(oplist => {
     oplist.forEach(op => {
       op.contents.forEach(c => {
-        if (c.kind === 'endorsement' && c.metadata.delegate === args.baker)
+        if (c.kind === 'attestation' && c.metadata.delegate === args.baker)
           endorsements++
       })
     })


### PR DESCRIPTION
https://octez.tezos.com/docs/releases/version-20.html#node oSince Octez version 18, RPCs accept both endorsements and attestations as input and/or output, with endorsement as default value but deprecated. Starting from version 20, attestation output is now the default. endorsement is still available, but it is deprecated and will be removed in a future version.

Discovered in: https://chorusone.slack.com/archives/C05ADDPJ685/p1721039711146059?thread_ts=1720536316.294589&cid=C05ADDPJ685

Related to: https://github.com/ChorusOne/chorus-infrastructure/issues/17597