### PR TITLE
Update URL to query attestation rights

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ var query = async () => {
     operation_endorsements_cycle.set(labels, getCurrentGaugeValue(operation_endorsements_cycle, labels)+1)
   }
 
-  let endorsingRights = await fetch(`${baseUri}/chains/${args.chain}/blocks/${block}/helpers/endorsing_rights?delegate=${args.baker}&level=${block}`)
+  let endorsingRights = await fetch(`${baseUri}/chains/${args.chain}/blocks/${block}/helpers/attestation_rights?delegate=${args.baker}&level=${block}`)
     .then(res => res.json())
     .catch(err => console.error(err.message))
 


### PR DESCRIPTION
The old `endorsement_rights` URL is deprecated in v21

See the v20 API spec to compare the two: https://gitlab.com/tezos/tezos/-/blob/octez-v20.3/docs/api/oxford-openapi.json?ref_type=tags

I can't see that the existing code is using the `endorsing_power` key anywhere, so it shouldn't matter that this is now called `attestation_power`.