### PR TITLE
fix(tezos): Handle attestation_with_dal kind

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,8 @@ var query = async () => {
   head.operations.forEach(oplist => {
     oplist.forEach(op => {
       op.contents.forEach(c => {
-        if (c.kind === 'attestation' && c.metadata.delegate === args.baker)
+        // Check for both kinds of attestations (minimal change)
+        if ((c.kind === 'attestation' || c.kind === 'attestation_with_dal') && c.metadata.delegate === args.baker)
           endorsements++
       })
     })


### PR DESCRIPTION
## Fix: Handle `attestation_with_dal` Kind for Endorsements

**Description:**

This PR addresses an issue in the `tezos-baking-exporter` where endorsements were not counted correctly for Tezos nodes with the Data Availability Layer (DAL) enabled. DAL-enabled nodes report attestations using the operation kind `attestation_with_dal`, but the previous logic only checked for `attestation`, resulting in missed endorsements.

**Changes:**
- Updated the condition in `index.js` to check for both `attestation` and `attestation_with_dal` operation kinds.
- Ensured accurate endorsement counting for all nodes.
